### PR TITLE
chore(core): remove shadowed variable, fix govet in updater.go\n fixe…

### DIFF
--- a/core/tasks.go
+++ b/core/tasks.go
@@ -131,7 +131,8 @@ func RotateTasks(event string) error {
 
 // runTasksRotator checks which tasks should be run and starts rotating
 func runTasksRotator(cChecks *CommonChecks, event string) error {
-	CurrentQueue, err := ListTasksDetailed()
+	var err error
+	CurrentQueue, err = ListTasksDetailed()
 	if err != nil {
 		return err
 	}

--- a/core/updater.go
+++ b/core/updater.go
@@ -21,11 +21,8 @@ var (
 // currently running
 func AreABRootTransactionsLocked() bool {
 	_, err := os.Stat(abrootLockPath)
-	if err != nil {
-		return false
-	}
 
-	return true
+	return err == nil
 }
 
 // NeedUpdate checks if the system needs to be updated according to the latest


### PR DESCRIPTION
…s #8
If applied, this patch will remove the shadowed CurrentQueue that masked the package level variable.

It also fixes a small govet issue in updater.go

fixes #8 