### PR TITLE
chore(config): fix config/show to display booleans properly

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -59,7 +59,7 @@ func config(cmd *cobra.Command, args []string) error {
 	switch args[0] {
 	case "show":
 		for _, key := range settings.GetConfigKeys() {
-			fmt.Printf("%s: %s\n", key, settings.GetConfigValue(key))
+			fmt.Printf("%s: %v\n", key, settings.GetConfigValue(key))
 		}
 	case "get":
 		if len(args) < 2 {


### PR DESCRIPTION
this patch makes `config show` use `%v` format to auto format booleans and strings without error.

fixes #11 