### PR TITLE
Fix `vso config` examples

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -34,8 +34,8 @@ Commands:
 	set <key> <value>	set a configuration value
 
 Examples:
-	vso config get updates::schedule
-	vso config set updates::schedule weekly
+	vso config get updates.schedule
+	vso config set updates.schedule weekly
 `)
 	return nil
 }


### PR DESCRIPTION
The examples in `vso config` still used `::` to index elements, which doesn't work anymore. This PR changes the separator to `.`.