### PR TITLE
Polkit support

### DIFF
--- a/cmd/check-for-updates.go
+++ b/cmd/check-for-updates.go
@@ -47,9 +47,9 @@ func NewCheckUpdateCommand() *cobra.Command {
 }
 
 func checkUpdate(cmd *cobra.Command, args []string) error {
-	if !core.RootCheck(true) {
-		return nil
-	}
+	// if !core.RootCheck(true) {
+	// 	return nil
+	// }
 
 	if !cmd.Flag("as-exit-code").Changed {
 		fmt.Println("Checking for updates...")

--- a/debian/vanilla-system-operator.install
+++ b/debian/vanilla-system-operator.install
@@ -3,4 +3,4 @@ man/vso.1 /usr/share/man/man1
 man/es/vso.1 /usr/share/man/es/man1
 man/fr/vso.1 /usr/share/man/fr/man1
 polkit/org.vanillaos.vso.pkla /var/lib/polkit-1/localauthority/10-vendor.d/
-org.vanillaos.vso.policy /usr/share/polkit-1/actions/
+polkit/org.vanillaos.vso.policy /usr/share/polkit-1/actions/

--- a/debian/vanilla-system-operator.install
+++ b/debian/vanilla-system-operator.install
@@ -2,3 +2,5 @@ config/config.json /etc/vso/
 man/vso.1 /usr/share/man/man1
 man/es/vso.1 /usr/share/man/es/man1
 man/fr/vso.1 /usr/share/man/fr/man1
+polkit/org.vanillaos.vso.pkla /var/lib/polkit-1/localauthority/10-vendor.d/
+org.vanillaos.vso.policy /usr/share/polkit-1/actions/

--- a/polkit/future/org.vanillaos.abroot.rules
+++ b/polkit/future/org.vanillaos.abroot.rules
@@ -1,0 +1,7 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.vanillaos.abroot.check_updates") {
+        polkit.log("action=" + action);
+        polkit.log("subject=" + subject);
+        return polkit.Result.YES;
+    }
+});

--- a/polkit/future/org.vanillaos.abroot.rules
+++ b/polkit/future/org.vanillaos.abroot.rules
@@ -1,5 +1,5 @@
 polkit.addRule(function(action, subject) {
-    if (action.id == "org.vanillaos.abroot.check_updates") {
+    if (action.id == "org.vanillaos.vso.check_updates") {
         polkit.log("action=" + action);
         polkit.log("subject=" + subject);
         return polkit.Result.YES;

--- a/polkit/org.vanillaos.vso.pkla
+++ b/polkit/org.vanillaos.vso.pkla
@@ -1,0 +1,6 @@
+[Allow admins to check for updates]
+Identity=unix-group:sudo
+Action=org.vanillaos.abroot.check_updates
+ResultAny=no
+ResultInactive=no
+ResultActive=yes

--- a/polkit/org.vanillaos.vso.pkla
+++ b/polkit/org.vanillaos.vso.pkla
@@ -1,6 +1,6 @@
 [Allow admins to check for updates]
 Identity=unix-group:sudo
-Action=org.vanillaos.abroot.check_updates
+Action=org.vanillaos.vso.check_updates
 ResultAny=no
 ResultInactive=no
 ResultActive=yes

--- a/polkit/org.vanillaos.vso.policy
+++ b/polkit/org.vanillaos.vso.policy
@@ -7,7 +7,7 @@
   <vendor_url>https://www.vanillaos.org/</vendor_url>
   <icon_name>package-x-generic</icon_name>
 
-  <action id="org.vanillaos.abroot.check_updates">
+  <action id="org.vanillaos.vso.check_updates">
     <description>Check for system package updates</description>
     <message>Authentication is required to check for updates</message>
     <icon_name>package-x-generic</icon_name>

--- a/polkit/org.vanillaos.vso.policy
+++ b/polkit/org.vanillaos.vso.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>Vanilla OS</vendor>
+  <vendor_url>https://www.vanillaos.org/</vendor_url>
+  <icon_name>package-x-generic</icon_name>
+
+  <action id="org.vanillaos.abroot.check_updates">
+    <description>Check for system package updates</description>
+    <message>Authentication is required to check for updates</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/vso</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">update-check</annotate>
+  </action>
+</policyconfig>


### PR DESCRIPTION
Adds a Polkit rule and action for allowing `vso update-check` calls made with `pkexec` (like the one in vanilla-control-center) to bypass root authentication as long as the user is part of the "sudo" gruup.

This also solves the only thing blocking work on a gnome-software plugin for system updates 👀 