### PR TITLE
Fix: Wrong error message when the subsystem is not initizalized

### DIFF
--- a/cmd/pico.go
+++ b/cmd/pico.go
@@ -21,7 +21,7 @@ func NewPicoCommand() []*cmdr.Command {
 	handleFunc := func() func(cmd *cobra.Command, args []string) error {
 		return func(cmd *cobra.Command, args []string) error {
 			if !core.PicoExists() {
-				cmdr.Error.Println("The Pico subsystem is not initialized. Please run `vso init-pico` to initialize it.")
+				cmdr.Error.Println("The Pico subsystem is not initialized. Please run `vso pico-init` to initialize it.")
 				return nil
 			}
 


### PR DESCRIPTION
If the subsystem is not initializated and you try to execute a command you get 
`The Pico subsystem is not initizalized. Please run 'vso init-pico' to initialize it`
Instead of
`The Pico subsystem is not initizalized. Please run 'vso pico-init' to initialize it`