### PR TITLE
feat/ci: bump workflows

### DIFF
--- a/.github/workflows/go-pr.yml
+++ b/.github/workflows/go-pr.yml
@@ -16,9 +16,9 @@ jobs:
           - uses: actions/checkout@v4
       
           - name: Set up Go
-            uses: actions/setup-go@v4
+            uses: actions/setup-go@v5
             with:
-              go-version: 1.19
+              go-version: 1.21
       
           - name: Install build dependencies
             run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,9 +14,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
@@ -35,9 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
## Changes

- Bump `actions/setup-go` to `v5` (Node 20).
- Bump `goreleaser/goreleaser-action` to `v5` (Node 20).
- Set the go version to 1.21.