### PR TITLE
feat: Allow positional args when calling vso shell

### DIFF
--- a/cmd/pico.go
+++ b/cmd/pico.go
@@ -216,7 +216,12 @@ func picoShell(cmd *cobra.Command, args []string) error {
 		picoShell(cmd, args)
 	}
 
-	return pico.Enter()
+	if len(args) == 0 {
+		return pico.Enter()
+	}
+
+	_, err = pico.Exec(false, false, args...)
+	return err
 }
 
 func picoRun(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This PR enhances the `vso shell` command by allowing the user to pass positional arguments to it. With this change, calling `vso shell -- tmux`, for instance, will immediately run tmux, which can be useful when configuring the launch command in other terminals.