### PR TITLE
feat: Allow disabling automatic updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /debian/debhelper-build-stamp
 /debian/vanilla-system-operator.substvars
 /vso
+vanilla-system-operator

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -125,10 +125,10 @@ func setConfig(cmd *cobra.Command, args []string) error {
 
 	err := settings.SetConfigValue(key, value)
 	if err != nil {
-		cmdr.Error.Println(vso.Trans("config.set.error.failed"), err)
+		cmdr.Error.Println(vso.Trans("config.set.error.failed", err))
 		return nil
 	}
 
-	cmdr.Info.Println(vso.Trans("config.set.success"), key, value)
+	cmdr.Info.Printf("%s '%s' = '%s'\n", vso.Trans("config.set.success"), key, value)
 	return nil
 }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -114,8 +114,15 @@ sysUpgrade:
     description: "Upgrade the system"
     error:
       updating: "An error occured when updating the system."
+      onHasUpdate: "Error while searching for updates: %s."
+    schedule:
+      daily: "daily"
+      weekly: "weekly"
+      monthly: "monthly"
     info:
       updating: "Updating the system..."
+      willUpdateLater: "An update is available and will be automatically installed based on your %s schedule. You can force the update using 'vso sys-upgrade upgrade --now'."
+      willNeverUpdate: "An update is available, but will not be automatically installed because you disabled automatic updates. You can force the update using 'vso sys-upgrade upgrade --now'."
       noUpdates: "Your system is already up-to-date."
     now: "Trigger a system upgrade now"
 


### PR DESCRIPTION
This commit adds the "never" option to "updates.schedule" which disables automatic updates. It also fixes a bug where `core.HasUpdates()` would ignore the update schedule and return true as soon as an update was available.

Pinging @kbdharun because of some new translation strings.