### PR TITLE
feat: rename 'sys-upgrade' command to 'sys'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Available Commands:
   run         Run an application from the subsystem
   search      Search for an application to install inside the subsystem
   shell       Enter the subsystem environment
-  sys-upgrade Upgrade the system
+  sys         Execute system tasks, such as upgrading the system
   tasks       Create and manage tasks
   unexport    Unexport an application or binary from the subsystem
   update      Update the subsystem's package repository

--- a/cmd/sys-upgrade.go
+++ b/cmd/sys-upgrade.go
@@ -22,11 +22,14 @@ import (
 func NewUpgradeCommand() *cmdr.Command {
 	// Root command
 	cmd := cmdr.NewCommand(
-		"sys-upgrade",
+		"sys",
 		vso.Trans("sysUpgrade.description"),
 		vso.Trans("sysUpgrade.description"),
 		nil,
 	)
+
+	// Backward compatibility
+	cmd.Aliases = []string{"sys-upgrade"}
 
 	// Subcommands
 	check := cmdr.NewCommand(

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -100,7 +100,7 @@ pico:
     description: "Upgrade the packages inside the subsystem"
 
 sysUpgrade:
-  description: "Upgrade the system"
+  description: "Execute system commands, such as upgrading the system"
   check:
     asExitCode: "checks for upgrade but doesn't print anything. Return exit code 0 if no upgrade is available and 1 otherwise."
     description: "Check for system updates"
@@ -111,7 +111,7 @@ sysUpgrade:
     json:
       description: "output the result in JSON format"
   sysUpgrade:
-    description: "Upgrade the system"
+    description: "Execute system commands, such as upgrading the system"
     error:
       updating: "An error occured when updating the system."
       onHasUpdate: "Error while searching for updates: %s."
@@ -121,8 +121,8 @@ sysUpgrade:
       monthly: "monthly"
     info:
       updating: "Updating the system..."
-      willUpdateLater: "An update is available and will be automatically installed based on your %s schedule. You can force the update using 'vso sys-upgrade upgrade --now'."
-      willNeverUpdate: "An update is available, but will not be automatically installed because you disabled automatic updates. You can force the update using 'vso sys-upgrade upgrade --now'."
+      willUpdateLater: "An update is available and will be automatically installed based on your %s schedule. You can force the update using 'vso sys upgrade --now'."
+      willNeverUpdate: "An update is available, but will not be automatically installed because you disabled automatic updates. You can force the update using 'vso sys upgrade --now'."
       noUpdates: "Your system is already up-to-date."
     now: "Trigger a system upgrade now"
 

--- a/main.go
+++ b/main.go
@@ -18,9 +18,7 @@ import (
 	"github.com/vanilla-os/vanilla-system-operator/cmd"
 )
 
-var (
-	Version = "2.0.1"
-)
+var Version = "2.0.1"
 
 //go:embed locales/*.yml
 var fs embed.FS

--- a/man/vso.1
+++ b/man/vso.1
@@ -19,9 +19,9 @@ The Vanilla System Operator is a package manager, a system updater and a task au
 Create and manage tasks
 .PP
 .RE
-\fBsys-upgrade\fP
+\fBsys\fP
 .RS 4
-Upgrade the system
+Execute system commands, such as upgrading the system
 .PP
 .RE
 \fBconfig\fP
@@ -135,18 +135,18 @@ Remove a task
 Rotate tasks
 .PP
 .RE
-.SH SUBCOMMAND SYS-UPGRADE
+.SH SUBCOMMAND SYS
 .RS 4
-Upgrade the system
+Execute system commands, such as upgrading the system
 .RE
 .SS SYNOPSIS
 .RS 4
-\fBsys-upgrade\fP [command] [flags] [arguments]
+\fBsys\fP [command] [flags] [arguments]
 .RE
 .SS DESCRIPTION
 .RS 4
 .TP 4
-Upgrade the system
+Execute system commands, such as upgrading the system
 .RE
 .SS OPTIONS
 .SS GLOBAL OPTIONS

--- a/polkit/org.vanillaos.vso.policy
+++ b/polkit/org.vanillaos.vso.policy
@@ -7,8 +7,8 @@
   <vendor_url>https://www.vanillaos.org/</vendor_url>
   <icon_name>package-x-generic</icon_name>
 
-  <action id="org.vanillaos.vso.sys-upgrade">
-    <description>Check for system package updates</description>
+  <action id="org.vanillaos.vso.sys">
+    <description>Execute system commands, such as upgrading the system</description>
     <message>Authentication is required to check for updates</message>
     <icon_name>package-x-generic</icon_name>
     <defaults>
@@ -17,6 +17,6 @@
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/vso</annotate>
-    <annotate key="org.freedesktop.policykit.exec.argv1">sys-upgrade</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">sys</annotate>
   </action>
 </policyconfig>

--- a/polkit/org.vanillaos.vso.rules
+++ b/polkit/org.vanillaos.vso.rules
@@ -1,5 +1,5 @@
 polkit.addRule(function(action, subject) {
-    if ((action.id == "org.vanillaos.vso.sys-upgrade" && subject.isInGroup("sudo"))
+    if ((action.id == "org.vanillaos.vso.sys" && subject.isInGroup("sudo"))
     {
         polkit.log("action=" + action);
         polkit.log("subject=" + subject);


### PR DESCRIPTION
This closes #126 

`sys-upgrade` Command is now `sys` (`sys-upgrade` still works as an alias), the filename remains the same (`sys-upgrade.go`), as well as the translation calls. This eliminates the need to write upgrade twice in commands such as `sys-upgrade upgrade`.