### PR TITLE
fix:[#146] tasks: delete file using slug

### DIFF
--- a/core/task-struct.go
+++ b/core/task-struct.go
@@ -300,7 +300,7 @@ func (t *Task) Unit() string {
 
 // Delete deletes a task
 func (t *Task) Delete() error {
-	err := os.Remove(getUserTasksLocation() + "/" + t.Name + ".vsotask")
+	err := os.Remove(getUserTasksLocation() + "/" + t.Slug + ".vsotask")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
use slug instead of filename for finding task file

closes #146 