### PR TITLE
fix:[#159] exit with generic error 1 if error detected

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"embed"
+	"os"
 
 	"github.com/vanilla-os/apx/v2/core"
 	"github.com/vanilla-os/apx/v2/settings"
@@ -74,5 +75,6 @@ func main() {
 	err := vso.Run()
 	if err != nil {
 		cmdr.Error.Println(err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
exit with generic (1) error if error is detected
```bash
vso sideload -- ../vanilla-installer_2.4.0_amd64.deb
```
```
Get:2 https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  InRelease [1,581 B]
Get:3 https://dl.google.com/linux/chrome/deb stable InRelease [1,825 B]
Err:2 https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Hit:1 https://repo2.vanillaos.org sid InRelease                  
Get:4 https://dl.google.com/linux/chrome/deb stable/main amd64 Packages [1,223 B]
Fetched 3,048 B in 1s (4,240 B/s)   
492 packages can be upgraded. Run 'apt list --upgradable' to see them.
Warning: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Warning: Failed to fetch https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Warning: Some index files failed to download. They have been ignored, or old ones used instead.
Note, selecting 'vanilla-installer' instead of '../vanilla-installer_2.4.0_amd64.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

Unsatisfied dependencies:
 vanilla-installer : Depends: albius but it is not installable
Error: Unable to correct problems, you have held broken packages.
Error: exit status 100
Usage:
  vso sideload [flags]

Flags:
  -h, --help   help for sideload

  ERROR   exit status 100
```
```bash
echo $?
```
```
1
```
```bash
vso sideload -- ~/Downloads/google-chrome-stable_current_amd64.deb
```
```
Hit:2 https://dl.google.com/linux/chrome/deb stable InRelease                                                          
Get:3 https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  InRelease [1,581 B]                    
Hit:1 https://repo2.vanillaos.org sid InRelease                                               
Err:3 https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Fetched 1,581 B in 1s (1,997 B/s)
492 packages can be upgraded. Run 'apt list --upgradable' to see them.
Warning: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Warning: Failed to fetch https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
Warning: Some index files failed to download. They have been ignored, or old ones used instead.
Note, selecting 'google-chrome-stable' instead of '/home/jardon/Downloads/google-chrome-stable_current_amd64.deb'
google-chrome-stable is already the newest version (130.0.6723.91-1).
The following packages were automatically installed and are no longer required:
  g++-13  g++-13-x86-64-linux-gnu  libcpdb-frontend2t64  libcpdb2t64
Use 'sudo apt autoremove' to remove them.

Summary:
  Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 491
 INFO  Exported 1 applications
```
```bash
echo $?
```
```
0
```

relates #159 