### PR TITLE
removes waydroid implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,8 +68,9 @@ func main() {
 	root.AddCommand(pico...)
 
 	// waydroid
-	way := cmd.NewWayCommand()
-	root.AddCommand(way...)
+	// disabled until properly implemented again
+	// way := cmd.NewWayCommand()
+	// root.AddCommand(way...)
 
 	// run the app
 	err := vso.Run()


### PR DESCRIPTION
This does not work currently so it's better to remove the command to avoid confusion.

I would leave the code in to make it easier to add the support back in at a later point if we want to.